### PR TITLE
Merged changes from new_variables_input

### DIFF
--- a/scripts/constituents.py
+++ b/scripts/constituents.py
@@ -112,7 +112,7 @@ class ConstituentVarDict(VarDictionary):
                 # end for
                 newdims.append(':'.join(new_dnames))
             # end for
-            var = source_var.clone({'dimensions' : newdims}, remove_intent=False,
+            var = source_var.clone({'dimensions' : newdims}, remove_intent=True,
                                    source_type=self.__constituent_type)
             self.add_variable(var, self.__run_env)
         return var

--- a/scripts/metavar.py
+++ b/scripts/metavar.py
@@ -1004,15 +1004,15 @@ class Var:
             intent = None
         # end if
         if protected and allocatable:
-            errmsg = 'Cannot create allocatable variable from protected, {}'
+            errmsg = "Cannot create allocatable variable from protected, {}"
             raise CCPPError(errmsg.format(name))
         # end if
         if dummy and (intent is None):
             if add_intent is not None:
                 intent = add_intent
             else:
-                errmsg = "<add_intent> is missing for dummy argument, {}"
-                raise CCPPError(errmsg.format(name))
+                errmsg = f"<add_intent> is missing for dummy argument, {name}"
+                raise CCPPError(errmsg)
             # end if
         # end if
         if protected and dummy:
@@ -1025,7 +1025,12 @@ class Var:
             # end if
         elif intent is not None:
             alloval = self.get_prop_value('allocatable')
-            if (intent.lower()[-3:] == 'out') and alloval:
+            if alloval:
+                if intent.lower() == 'in':
+                    # We should not have allocatable, intent(in), makes no sense
+                    errmsg = f"{name} ({stdname}) is allocatable and intent(in)"
+                    raise CCPPError(errmsg)
+                # end if
                 intent_str = f"allocatable, intent({intent})"
             else:
                 intent_str = f"intent({intent}){' '*(5 - len(intent))}"
@@ -1064,7 +1069,7 @@ class Var:
                 cspc = comma + ' '*(extra_space + 19 - len(vtype))
             # end if
         # end if
-            
+
         outfile.write(dstr.format(type=vtype, kind=kind, intent=intent_str,
                                   name=name, dims=dimstr, cspc=cspc,
                                   sname=stdname), indent)

--- a/test/var_action_test/run_test
+++ b/test/var_action_test/run_test
@@ -6,7 +6,7 @@ scriptdir="$( cd $( dirname $0 ); pwd -P )"
 ##
 ## Option default values
 ##
-defdir="ct_build"
+defdir="va_build"
 build_dir="${currdir}/${defdir}"
 cleanup="PASS" # Other supported options are ALWAYS and NEVER
 verbosity=0


### PR DESCRIPTION
Merged changes from new_variables_input

Reimplement suite variables interface to include `phases` input to allow a
host model to request variables from selected phases.
Restore removal of `intent` in constituents dictionary.
Also rename dir for var_action test to distinguish from ct_build

User interface changes?: Yes
New, optional variable, `phases`, to `ccpp_physics_suite_variables` interface routine.

Testing:
./test/run_tests passed except for known fail, var_action test.
