### PR TITLE
Initial removing python 2 and < 3.7 code checks.

### DIFF
--- a/scripts/ccpp_datafile.py
+++ b/scripts/ccpp_datafile.py
@@ -27,10 +27,6 @@ from metavar import Var
 from parse_tools import read_xml_file, PrettyElementTree
 from suite_objects import VerticalLoop, Subcycle
 
-# Find python version
-PY3 = sys.version_info[0] > 2
-PYSUBVER = sys.version_info[1]
-
 # Global data
 _INDENT_STR = "  "
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -165,14 +165,7 @@ def escape_tex(text):
 
 def isstring(s):
     """Return true if a variable is a string"""
-    # We use Python 3
-    if (sys.version_info.major == 3):
-        return isinstance(s, str)
-    # We use Python 2
-    elif (sys.version_info.major == 2):
-        return isinstance(s, basestring)
-    else:
-        raise Exception('Unknown Python version')
+    return isinstance(s, str)
 
 def string_to_python_identifier(string):
     """Replaces forbidden characters in strings with standard substitutions

--- a/scripts/file_utils.py
+++ b/scripts/file_utils.py
@@ -13,11 +13,7 @@ import glob
 import os
 # CCPP framework imports
 from parse_tools import CCPPError, ParseInternalError
-#XXgoldyXX: v Crap required to support python 2
 import sys
-# Find python version
-PY3 = sys.version_info[0] > 2
-#XXgoldyXX: ^ Crap required to support python 2
 
 # Standardize name of generated kinds file and module
 KINDS_MODULE = 'ccpp_kinds'
@@ -300,13 +296,7 @@ def move_modified_files(src_dir, dest_dir, overwrite=False, remove_src=False):
                 fmove = True
             # end if
             if fmove:
-#XXgoldyXX: v Crap required to support python 2
-                if PY3:
-                    os.replace(src_path, dest_path)
-                else:
-                    os.rename(src_path, dest_path)
-                # end if
-#XXgoldyXX: ^ Crap required to support python 2
+                os.replace(src_path, dest_path)
             else:
                 os.remove(src_path)
             # end if

--- a/scripts/file_utils.py
+++ b/scripts/file_utils.py
@@ -13,7 +13,6 @@ import glob
 import os
 # CCPP framework imports
 from parse_tools import CCPPError, ParseInternalError
-import sys
 
 # Standardize name of generated kinds file and module
 KINDS_MODULE = 'ccpp_kinds'

--- a/scripts/parse_tools/parse_source.py
+++ b/scripts/parse_tools/parse_source.py
@@ -2,16 +2,14 @@
 
 """Classes to aid the parsing process"""
 
-import sys
 
-# pylint: disable=wrong-import-position
 # Python library imports
 from collections.abc import Iterable
 import copy
+import sys
 import os.path
 import logging
 # CCPP framework imports
-# pylint: enable=wrong-import-position
 
 class _StdNameCounter:
     """Class to hold a global counter to avoid using global keyword"""

--- a/scripts/parse_tools/parse_source.py
+++ b/scripts/parse_tools/parse_source.py
@@ -3,16 +3,10 @@
 """Classes to aid the parsing process"""
 
 import sys
-# Find python version
-PY3 = sys.version_info[0] > 2
 
 # pylint: disable=wrong-import-position
 # Python library imports
-if PY3:
-    from collections.abc import Iterable
-else:
-    from collections import Iterable
-# end if
+from collections.abc import Iterable
 import copy
 import os.path
 import logging

--- a/scripts/parse_tools/xml_tools.py
+++ b/scripts/parse_tools/xml_tools.py
@@ -256,14 +256,14 @@ class PrettyElementTree(ET.ElementTree):
         """Subclassed write method to format output."""
         if PYSUBVER >= 8:
             et_str = ET.tostring(self.getroot(),
-                                    encoding=encoding, method=method,
-                                    xml_declaration=xml_declaration,
-                                    default_namespace=default_namespace,
-                                    short_empty_elements=short_empty_elements)
+                                 encoding=encoding, method=method,
+                                 xml_declaration=xml_declaration,
+                                 default_namespace=default_namespace,
+                                 short_empty_elements=short_empty_elements)
         else:
             et_str = ET.tostring(self.getroot(),
-                                    encoding=encoding, method=method,
-                                    short_empty_elements=short_empty_elements)
+                                 encoding=encoding, method=method,
+                                 short_empty_elements=short_empty_elements)
         # end if
         fmode = 'wt'
         root = str(et_str, encoding="utf-8")

--- a/scripts/parse_tools/xml_tools.py
+++ b/scripts/parse_tools/xml_tools.py
@@ -53,24 +53,12 @@ def call_command(commands, logger, silent=False):
     result = False
     outstr = ''
     try:
-        if PYSUBVER > 6:
-            cproc = subprocess.run(commands, check=True,
-                                    capture_output=True)
-            if not silent:
-                logger.debug(cproc.stdout)
-            # end if
-            result = cproc.returncode == 0
-        elif PYSUBVER >= 5:
-            cproc = subprocess.run(commands, check=True,
-                                    stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
-            if not silent:
-                logger.debug(cproc.stdout)
-            # end if
-            result = cproc.returncode == 0
-        else:
-            raise ValueError("Python 3 must be at least version 3.5")
+        cproc = subprocess.run(commands, check=True,
+                                capture_output=True)
+        if not silent:
+            logger.debug(cproc.stdout)
         # end if
+        result = cproc.returncode == 0
     except (OSError, CCPPError, subprocess.CalledProcessError) as err:
         if silent:
             result = False
@@ -266,21 +254,16 @@ class PrettyElementTree(ET.ElementTree):
               default_namespace=None, method="xml",
               short_empty_elements=True):
         """Subclassed write method to format output."""
-        if PYSUBVER >= 4:
-            if PYSUBVER >= 8:
-                et_str = ET.tostring(self.getroot(),
-                                     encoding=encoding, method=method,
-                                     xml_declaration=xml_declaration,
-                                     default_namespace=default_namespace,
-                                     short_empty_elements=short_empty_elements)
-            else:
-                et_str = ET.tostring(self.getroot(),
-                                     encoding=encoding, method=method,
-                                     short_empty_elements=short_empty_elements)
-            # end if
+        if PYSUBVER >= 8:
+            et_str = ET.tostring(self.getroot(),
+                                    encoding=encoding, method=method,
+                                    xml_declaration=xml_declaration,
+                                    default_namespace=default_namespace,
+                                    short_empty_elements=short_empty_elements)
         else:
             et_str = ET.tostring(self.getroot(),
-                                 encoding=encoding, method=method)
+                                    encoding=encoding, method=method,
+                                    short_empty_elements=short_empty_elements)
         # end if
         fmode = 'wt'
         root = str(et_str, encoding="utf-8")

--- a/test/advection_test/test_reports.py
+++ b/test/advection_test/test_reports.py
@@ -22,8 +22,8 @@ if not os.path.exists(_SCRIPTS_DIR):
 # end if
 
 if ((sys.version_info[0] < 3) or
-    (sys.version_info[0] == 3) and (sys.version_info[1] < 6)):
-    raise Exception("Python 3.6 or greater required")
+    (sys.version_info[0] == 3) and (sys.version_info[1] < 7)):
+    raise Exception("Python 3.7 or greater required")
 # end if
 
 sys.path.append(_SCRIPTS_DIR)


### PR DESCRIPTION
Remove Python major version checks

As Python 2 has been EOL'd for a few years now, there is no longer a need to check if python is version 2 or 3.  Still maintaining python 3 sub-version checks for some backwards compatibility greater than or equal to 2.7.

User interface changes?: No

Fixes: None

Testing:
  test removed: None
  unit tests: all in /test
  system tests: None
  manual testing: None

