### PR TITLE
Add missing error flag and error message

### DIFF
--- a/scripts/constituents.py
+++ b/scripts/constituents.py
@@ -646,6 +646,10 @@ class ConstituentVarDict(VarDictionary):
         for evar in err_vars:
             evar.write_def(cap, 2, host, dummy=True, add_intent="out")
         # end for
+        cap.blank_line()
+        cap.write(f"{herrcode} = 0", 2)
+        cap.write(f"{herrmsg} = ''", 2)
+        cap.blank_line()
         cap.write("constituent_exists = .false.", 2)
         cap.write(f"if (any({host.name}_model_const_stdnames == var_name)) then", 2)
         cap.write("constituent_exists = .true.", 3)


### PR DESCRIPTION
Add missing error flag and message in new `is_scheme_constituent` subroutine

### Description:

There were two `intent(out)` quantities that weren't actually being set, and thus
causing problems upstream.

### User interface changes?: 

No

### Fixes: 

No official github issue right now, but can make one if you want.

### Testing:  

Used the subroutine in a CAM-SIMA physics testbed configuration with the Held-Suarez physics suite.
