### PR TITLE
Sort sets before writing

### DIFF
--- a/scripts/ccpp_suite.py
+++ b/scripts/ccpp_suite.py
@@ -1088,7 +1088,7 @@ class API(VarDictionary):
             ofile.write("allocate({}({}))".format(varlist_name, len(var_list)),
                         indent)
         # end if
-        for ind, var in enumerate(var_list):
+        for ind, var in enumerate(sorted(var_list)):
             if start_var:
                 ind_str = "{} + {}".format(start_var, ind + start_index)
             else:
@@ -1136,7 +1136,7 @@ class API(VarDictionary):
         ofile.write("\nsubroutine {}({})".format(API.__vars_fname, inargs), 1)
         # Declare use statements for suite varlist routines
         mlen = max([len(x.module) for x in self.suites])
-        for suite in self.suites:
+        for suite in sorted(self.suites):
             mod = f"{suite.module}{' '*(mlen - len(suite.module))}"
             ofile.write(f"use {mod}, only: {suite.req_vars_subname()}", 2)
         # end for

--- a/scripts/ccpp_suite.py
+++ b/scripts/ccpp_suite.py
@@ -1136,7 +1136,7 @@ class API(VarDictionary):
         ofile.write("\nsubroutine {}({})".format(API.__vars_fname, inargs), 1)
         # Declare use statements for suite varlist routines
         mlen = max([len(x.module) for x in self.suites])
-        for suite in sorted(self.suites):
+        for suite in self.suites:
             mod = f"{suite.module}{' '*(mlen - len(suite.module))}"
             ofile.write(f"use {mod}, only: {suite.req_vars_subname()}", 2)
         # end for

--- a/scripts/host_cap.py
+++ b/scripts/host_cap.py
@@ -432,7 +432,7 @@ def write_host_cap(host_model, api, module_name, output_dir, run_env):
         mlen = max([len(x.module) for x in api.suites])
         maxmod = max(maxmod, mlen)
         maxmod = max(maxmod, len(CONST_DDT_MOD))
-        for mod in modules:
+        for mod in sorted(modules):
             mspc = (maxmod - len(mod[0]))*' '
             cap.write("use {}, {}only: {}".format(mod[0], mspc, mod[1]), 1)
         # End for
@@ -530,7 +530,7 @@ def write_host_cap(host_model, api, module_name, output_dir, run_env):
             for suite in api.suites:
                 mspc = (max_suite_len - len(suite.module))*' '
                 spart_list = suite_part_list(suite, stage)
-                for spart in spart_list:
+                for spart in sorted(spart_list):
                     stmt = "use {}, {}only: {}"
                     cap.write(stmt.format(suite.module, mspc, spart.name), 2)
                 # End for

--- a/scripts/suite_objects.py
+++ b/scripts/suite_objects.py
@@ -1787,7 +1787,7 @@ class Group(SuiteObject):
         # end if
         # Write out the scheme use statements
         scheme_use = 'use {},{} only: {}'
-        for scheme in self._local_schemes:
+        for scheme in sorted(self._local_schemes):
             smod = scheme[0]
             sname = scheme[1]
             slen = ' '*(modmax - len(smod))
@@ -1853,7 +1853,7 @@ class Group(SuiteObject):
                                        'funcname' : self.name})
         # Allocate local arrays
         alloc_stmt = "allocate({}({}))"
-        for lname in allocatable_var_set:
+        for lname in sorted(allocatable_var_set):
             var = subpart_vars[lname][0]
             dims = var.get_dimensions()
             alloc_str = self.allocate_dim_str(dims, var.context)
@@ -1886,7 +1886,7 @@ class Group(SuiteObject):
           item.write(outfile, errcode, indent + 1)
         # end for
         # Deallocate local arrays
-        for lname in allocatable_var_set:
+        for lname in sorted(allocatable_var_set):
             outfile.write('deallocate({})'.format(lname), indent+1)
         # end for
         # Deallocate suite vars


### PR DESCRIPTION
Sort sets before writing to files to ease comparison between runs.

### Description
In order to make it easier to compare generated code, this PR makes modifications to sort sets right before writing to the files. This includes use statements, allocate statements, 

User interface changes?: No

Testing:
  tests are passing

