### PR TITLE
Add molecular weight property functionality

### DIFF
--- a/src/ccpp_constituent_prop_mod.F90
+++ b/src/ccpp_constituent_prop_mod.F90
@@ -733,7 +733,7 @@ CONTAINS
               (this%advected .eqv. oconst%advected)                     .and. &
               (this%const_default_value == oconst%const_default_value)  .and. &
               (this%min_val == oconst%min_val)                          .and. &
-              (this%molar_mass = oconst%molar_mass)                     .and. &
+              (this%molar_mass == oconst%molar_mass)                    .and. &
               (this%thermo_active .eqv. oconst%thermo_active)           .and. &
               (this%water_species .eqv. oconst%water_species)
       else
@@ -908,10 +908,10 @@ CONTAINS
    subroutine ccp_set_molec_weight(this, molec_weight, errcode, errmsg)
 
       ! Dummy arguments
-      class(ccpp_constituent_properties_t), intent(in)  :: this
-      real(kind_phys),                      intent(in)  :: molec_weight
-      integer,                              intent(out) :: errcode
-      character(len=*),                     intent(out) :: errmsg
+      class(ccpp_constituent_properties_t), intent(inout) :: this
+      real(kind_phys),                      intent(in)    :: molec_weight
+      integer,                              intent(out)   :: errcode
+      character(len=*),                     intent(out)   :: errmsg
 
       if (this%is_instantiated(errcode, errmsg)) then
           this%molar_mass = molec_weight
@@ -2276,10 +2276,10 @@ CONTAINS
    subroutine ccpt_set_molec_weight(this, molec_weight, errcode, errmsg)
 
       ! Dummy arguments
-      class(ccpp_constituent_prop_ptr_t), intent(in)  :: this
-      real(kind_phys),                    intent(in)  :: molec_weight
-      integer,                            intent(out) :: errcode
-      character(len=*),                   intent(out) :: errmsg
+      class(ccpp_constituent_prop_ptr_t), intent(inout) :: this
+      real(kind_phys),                    intent(in)    :: molec_weight
+      integer,                            intent(out)   :: errcode
+      character(len=*),                   intent(out)   :: errmsg
       ! Local variable
       character(len=*), parameter :: subname = 'ccpt_set_molec_weight'
 

--- a/src/ccpp_constituent_prop_mod.F90
+++ b/src/ccpp_constituent_prop_mod.F90
@@ -45,7 +45,7 @@ module ccpp_constituent_prop_mod
       integer,          private              :: const_water = int_unassigned
       ! minimum_mr is the minimum allowed value (default zero)
       real(kind_phys),  private              :: min_val = 0.0_kind_phys
-      ! molar_mass is the molecular weight of the constituent (g mol-1)
+      ! molar_mass is the molecular weight of the constituent (kg mol-1)
       real(kind_phys),  private              :: molar_mass = kphys_unassigned
       ! default_value is the default value that the constituent array will be
       ! initialized to
@@ -86,6 +86,7 @@ module ccpp_constituent_prop_mod
       procedure :: set_thermo_active => ccp_set_thermo_active
       procedure :: set_water_species => ccp_set_water_species
       procedure :: set_minimum       => ccp_set_min_val
+      procedure :: set_molec_weight  => ccp_set_molec_weight
    end type ccpp_constituent_properties_t
 
 !! \section arg_table_ccpp_constituent_prop_ptr_t
@@ -123,6 +124,7 @@ module ccpp_constituent_prop_mod
       procedure :: set_thermo_active => ccpt_set_thermo_active
       procedure :: set_water_species => ccpt_set_water_species
       procedure :: set_minimum       => ccpt_set_min_val
+      procedure :: set_molec_weight  => ccpt_set_molec_weight
    end type ccpp_constituent_prop_ptr_t
 
 !! \section arg_table_ccpp_model_constituents_t
@@ -208,15 +210,18 @@ CONTAINS
       class(ccpp_constituent_properties_t), intent(inout) :: outConst
       type(ccpp_constituent_properties_t),  intent(in)    :: inConst
 
-      outConst%var_std_name = inConst%var_std_name
-      outConst%var_long_name = inConst%var_long_name
-      outConst%vert_dim = inConst%vert_dim
-      outConst%const_ind = inConst%const_ind
-      outConst%advected = inConst%advected
-      outConst%const_type = inConst%const_type
-      outConst%const_water = inConst%const_water
-      outConst%min_val = inConst%min_val
+      outConst%var_std_name        = inConst%var_std_name
+      outConst%var_long_name       = inConst%var_long_name
+      outConst%vert_dim            = inConst%vert_dim
+      outConst%const_ind           = inConst%const_ind
+      outConst%advected            = inConst%advected
+      outConst%const_type          = inConst%const_type
+      outConst%const_water         = inConst%const_water
+      outConst%min_val             = inConst%min_val
       outConst%const_default_value = inConst%const_default_value
+      outConst%molar_mass          = inConst%molar_mass
+      outConst%thermo_active       = inConst%thermo_active
+      outConst%water_species       = inConst%water_species
    end subroutine copyConstituent
 
    !#######################################################################
@@ -374,7 +379,7 @@ CONTAINS
    !#######################################################################
 
    subroutine ccp_instantiate(this, std_name, long_name, units, vertical_dim,  &
-        advected, default_value, errcode, errmsg)
+        advected, default_value, min_value, molec_weight, errcode, errmsg)
       ! Initialize all fields in <this>
 
       ! Dummy arguments
@@ -385,6 +390,8 @@ CONTAINS
       character(len=*),                     intent(in)    :: vertical_dim
       logical, optional,                    intent(in)    :: advected
       real(kind_phys), optional,            intent(in)    :: default_value
+      real(kind_phys), optional,            intent(in)    :: min_value
+      real(kind_phys), optional,            intent(in)    :: molec_weight
       integer,                              intent(out)   :: errcode
       character(len=*),                     intent(out)   :: errmsg
 
@@ -408,6 +415,12 @@ CONTAINS
          end if
          if (present(default_value)) then
             this%const_default_value = default_value
+         end if
+         if (present(min_value)) then
+            this%min_val = min_value
+         end if
+         if (present(molec_weight)) then
+            this%molar_mass = molec_weight
          end if
       end if
       if (errcode == 0) then
@@ -719,6 +732,8 @@ CONTAINS
               (trim(this%vert_dim) == trim(oconst%vert_dim))            .and. &
               (this%advected .eqv. oconst%advected)                     .and. &
               (this%const_default_value == oconst%const_default_value)  .and. &
+              (this%min_val == oconst%min_val)                          .and. &
+              (this%molar_mass = oconst%molar_mass)                     .and. &
               (this%thermo_active .eqv. oconst%thermo_active)           .and. &
               (this%water_species .eqv. oconst%water_species)
       else
@@ -887,6 +902,22 @@ CONTAINS
       end if
 
    end subroutine ccp_molec_weight
+
+   !########################################################################
+
+   subroutine ccp_set_molec_weight(this, molec_weight, errcode, errmsg)
+
+      ! Dummy arguments
+      class(ccpp_constituent_properties_t), intent(in)  :: this
+      real(kind_phys),                      intent(in)  :: molec_weight
+      integer,                              intent(out) :: errcode
+      character(len=*),                     intent(out) :: errmsg
+
+      if (this%is_instantiated(errcode, errmsg)) then
+          this%molar_mass = molec_weight
+      end if
+
+   end subroutine ccp_set_molec_weight
 
    !########################################################################
 
@@ -2239,6 +2270,27 @@ CONTAINS
       end if
 
    end subroutine ccpt_molec_weight
+
+   !########################################################################
+
+   subroutine ccpt_set_molec_weight(this, molec_weight, errcode, errmsg)
+
+      ! Dummy arguments
+      class(ccpp_constituent_prop_ptr_t), intent(in)  :: this
+      real(kind_phys),                    intent(in)  :: molec_weight
+      integer,                            intent(out) :: errcode
+      character(len=*),                   intent(out) :: errmsg
+      ! Local variable
+      character(len=*), parameter :: subname = 'ccpt_set_molec_weight'
+
+      if (associated(this%prop)) then
+         call this%prop%set_molec_weight(molec_weight, errcode, errmsg)
+      else
+         call set_errvars(1, subname//": invalid constituent pointer",        &
+              errcode=errcode, errmsg=errmsg)
+      end if
+
+   end subroutine ccpt_set_molec_weight
 
    !########################################################################
 

--- a/test/advection_test/test_host.F90
+++ b/test/advection_test/test_host.F90
@@ -323,7 +323,7 @@ CONTAINS
       call host_constituents(1)%instantiate(std_name="specific_humidity",     &
            long_name="Specific humidity", units="kg kg-1",                    &
            vertical_dim="vertical_layer_dimension", advected=.true.,          &
-           min_value=1000._kind_phys, molec_weight=2000._kind_phys,           &
+           min_value=1000._kind_phys, molar_mass=2000._kind_phys,           &
            errcode=errflg, errmsg=errmsg)
       call check_errflg(subname//'.initialize', errflg, errmsg, errflg_final)
       if (errflg == 0) then
@@ -543,7 +543,7 @@ CONTAINS
 
       !Check that a constituent instantiated with a specified molecular
       !weight actually contains that molecular weight property value:
-      call const_props(index)%molec_weight(check_value, errflg, errmsg)
+      call const_props(index)%molar_mass(check_value, errflg, errmsg)
       if (errflg /= 0) then
          write(6, '(a,i0,a,a,i0,/,a)') "ERROR: Error, ", errflg, " trying ",  &
               "to get molecular weight for specific humidity index = ",       &
@@ -552,7 +552,7 @@ CONTAINS
       end if
       if (errflg == 0) then
          if (check_value /= 2000._kind_phys) then !Should be 2000
-            write(6, *) "ERROR: 'molec_weight' should give a value of 2000 ", &
+            write(6, *) "ERROR: 'molar_mass' should give a value of 2000 ", &
                  "for specific humidity, as was set during instantiation."
             errflg_final = -1 !Notify test script that a failure occured
          end if
@@ -563,7 +563,7 @@ CONTAINS
 
       !Check that setting a constituent's molecular weight works
       !as expected:
-      call const_props(index_ice)%set_molec_weight(1._kind_phys, errflg,      &
+      call const_props(index_ice)%set_molar_mass(1._kind_phys, errflg,      &
                        errmsg)
       if (errflg /= 0) then
          write(6, '(a,i0,a,a,i0,/,a)') "ERROR: Error, ", errflg, " trying ",  &
@@ -572,7 +572,7 @@ CONTAINS
          errflg_final = -1 !Notify test script that a failure occurred
       end if
       if (errflg == 0) then
-         call const_props(index_ice)%molec_weight(check_value, errflg, errmsg)
+         call const_props(index_ice)%molar_mass(check_value, errflg, errmsg)
          if (errflg /= 0) then
             write(6, '(a,i0,a,i0,/,a)') "ERROR: Error, ", errflg,             &
                  " trying to get molecular weight for cld_ice index = ",      &
@@ -582,7 +582,7 @@ CONTAINS
       end if
       if (errflg == 0) then
          if (check_value /= 1._kind_phys) then !Should be equal to one
-            write(6, *) "ERROR: 'set_molec_weight' did not set constituent",  &
+            write(6, *) "ERROR: 'set_molar_mass' did not set constituent",  &
                  " molecular weight value correctly."
             errflg_final = -1 !Notify test script that a failure occurred
          end if

--- a/test/advection_test/test_host.F90
+++ b/test/advection_test/test_host.F90
@@ -323,6 +323,7 @@ CONTAINS
       call host_constituents(1)%instantiate(std_name="specific_humidity",     &
            long_name="Specific humidity", units="kg kg-1",                    &
            vertical_dim="vertical_layer_dimension", advected=.true.,          &
+           min_value=1000._kind_phys, molec_weight=2000._kind_phys,           &
            errcode=errflg, errmsg=errmsg)
       call check_errflg(subname//'.initialize', errflg, errmsg, errflg_final)
       if (errflg == 0) then
@@ -487,6 +488,26 @@ CONTAINS
          errflg = 0
       end if
 
+      !Check that a constituent instantiated with a specified minimum value
+      !actually contains that minimum value property:
+      call const_props(index)%minimum(check_value, errflg, errmsg)
+      if (errflg /= 0) then
+         write(6, '(a,i0,a,a,i0,/,a)') "ERROR: Error, ", errflg, " trying ",  &
+              "to get minimum value for specific humidity index = ", index,   &
+              trim(errmsg)
+         errflg_final = -1 !Notify test script that a failure occurred
+      end if
+      if (errflg == 0) then
+         if (check_value /= 1000._kind_phys) then !Should be 1000
+            write(6, *) "ERROR: 'minimum' should give a value of 1000 ",      &
+                 "for specific humidity, as was set during instantiation."
+            errflg_final = -1 !Notify test script that a failure occured
+         end if
+      else
+         !Reset error flag to continue testing other properties:
+         errflg = 0
+      end if
+
       !Check that setting a constituent's minimum value works
       !as expected:
       call const_props(index_ice)%set_minimum(1._kind_phys, errflg, errmsg)
@@ -509,6 +530,60 @@ CONTAINS
          if (check_value /= 1._kind_phys) then !Should now be one
             write(6, *) "ERROR: 'set_minimum' did not set constituent",       &
                  " minimum value correctly."
+            errflg_final = -1 !Notify test script that a failure occurred
+         end if
+      else
+         !Reset error flag to continue testing other properties:
+         errflg = 0
+      end if
+
+      !----------------------
+      !molecular weight tests:
+      !----------------------
+
+      !Check that a constituent instantiated with a specified molecular
+      !weight actually contains that molecular weight property value:
+      call const_props(index)%molec_weight(check_value, errflg, errmsg)
+      if (errflg /= 0) then
+         write(6, '(a,i0,a,a,i0,/,a)') "ERROR: Error, ", errflg, " trying ",  &
+              "to get molecular weight for specific humidity index = ",       &
+              index, trim(errmsg)
+         errflg_final = -1 !Notify test script that a failure occurred
+      end if
+      if (errflg == 0) then
+         if (check_value /= 2000._kind_phys) then !Should be 2000
+            write(6, *) "ERROR: 'molec_weight' should give a value of 2000 ", &
+                 "for specific humidity, as was set during instantiation."
+            errflg_final = -1 !Notify test script that a failure occured
+         end if
+      else
+         !Reset error flag to continue testing other properties:
+         errflg = 0
+      end if
+
+      !Check that setting a constituent's molecular weight works
+      !as expected:
+      call const_props(index_ice)%set_molec_weight(1._kind_phys, errflg,      &
+                       errmsg)
+      if (errflg /= 0) then
+         write(6, '(a,i0,a,a,i0,/,a)') "ERROR: Error, ", errflg, " trying ",  &
+              "to set molecular weight for cld_ice index = ", index_ice,      &
+              trim(errmsg)
+         errflg_final = -1 !Notify test script that a failure occurred
+      end if
+      if (errflg == 0) then
+         call const_props(index_ice)%molec_weight(check_value, errflg, errmsg)
+         if (errflg /= 0) then
+            write(6, '(a,i0,a,i0,/,a)') "ERROR: Error, ", errflg,             &
+                 " trying to get molecular weight for cld_ice index = ",      &
+                 index_ice, trim(errmsg)
+            errflg_final = -1 !Notify test script that a failure occurred
+         end if
+      end if
+      if (errflg == 0) then
+         if (check_value /= 1._kind_phys) then !Should be equal to one
+            write(6, *) "ERROR: 'set_molec_weight' did not set constituent",  &
+                 " molecular weight value correctly."
             errflg_final = -1 !Notify test script that a failure occurred
          end if
       else


### PR DESCRIPTION
**Add new methods for a user to set the molecular weight of a constituent.**

Added new methods to allow a user to set the molecular weight of a 
constituent, as well as to set the molecular weight and minimum value
of a constituent during instantiation. 

Also added new unit tests to make sure those new methods are working
properly.

User interface changes?: Yes

There is now a new `set_molec_weight` method that allows someone to set
the molecular weight property for a given constituent.  There are also new
`min_value` and `molec_weight` optional input variables  into the `instantiate`
method to allow the constituent minimum value and molecular weight 
properties to be set during object instantiation as well.

Fixes #11 -> Need a way to set constituent molecular weights

Testing:
  test removed: No tests removed.
  unit tests: All tests passed, including newly added unit tests.
  system tests: No system testing done.
  manual testing: No manual testing done.

